### PR TITLE
Initial rails application template

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GOV.UK stack.
 ## How to use
 
 ```shell
-rails new APP_NAME -m http://raw.github.com/govuk-rails-app-template/master/template.rb
+rails new APP_NAME --skip-test-unit -m govuk-rails-app-template/template.rb
 ```
 
 ## What it will do

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GOV.UK stack.
 ## How to use
 
 ```shell
-rails new APP_NAME --skip-test-unit --skip-spring -m govuk-rails-app-template/template.rb
+RBENV_VERSION=2.2.2 rails new APP_NAME --skip-javascript --skip-test-unit --skip-spring -m govuk-rails-app-template/template.rb
 ```
 
 ## What it will do

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GOV.UK stack.
 ## How to use
 
 ```shell
-rails new APP_NAME --skip-test-unit -m govuk-rails-app-template/template.rb
+rails new APP_NAME --skip-test-unit --skip-spring -m govuk-rails-app-template/template.rb
 ```
 
 ## What it will do

--- a/template.rb
+++ b/template.rb
@@ -13,7 +13,7 @@ template 'templates/README.md.erb', 'README.md'
 template 'templates/LICENSE.erb', 'LICENSE'
 
 # Enable JSON-formatted logging in production
-application nil, env: "production" do <<-'RUBY'
+environment nil, env: "production" do <<-'RUBY'
 config.logstasher.enabled = true
   config.logstasher.logger = Logger.new(Rails.root.join("/log/production.json.log"))
   config.logstasher.suppress_app_log = true
@@ -23,14 +23,4 @@ end
 gsub_file 'config/environments/production.rb', 'config.log_formatter = ::Logger::Formatter.new', '# config.log_formatter = ::Logger::Formatter.new'
 
 # Configure JSON-formatted logging with additional fields
-initializer "logstasher.rb" do <<-'RUBY'
-if Object.const_defined?('LogStasher') && LogStasher.enabled
-  LogStasher.add_custom_fields do |fields|
-    # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
-    fields[:request] = "\#{request.request_method} \#{request.fullpath} \#{request.headers['SERVER_PROTOCOL']}"
-    # Pass request Id to logging
-    fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
-  end
-end
-RUBY
-end
+initializer "logstasher.rb", File.read("#{File.dirname(__FILE__)}/templates/initializers/logstasher.rb")

--- a/template.rb
+++ b/template.rb
@@ -4,7 +4,7 @@ source_paths << File.dirname(__FILE__)
 run 'bundle install'
 git :init
 git add: "."
-git commit: "-a -m 'Bare Rails application'"
+git commit: "-a -m 'Bare Rails application\nGenerated using https://github.com/alphagov/govuk-rails-app-template'"
 
 # Configure JSON-formatted logging
 gem 'logstasher'

--- a/template.rb
+++ b/template.rb
@@ -29,7 +29,7 @@ git commit: "-a -m 'Use logstasher for JSON-formatted logging in production'"
 gem_group :development, :test do
   gem 'rspec-rails'
 end
-generate(:"rspec:install")
+generate("rspec:install")
 remove_dir('test')
 git add: "."
 git commit: "-a -m 'Use rspec-rails for testing'"
@@ -61,3 +61,23 @@ copy_file 'templates/spec/requests/healthcheck_spec.rb', 'spec/requests/healthch
 
 git add: "."
 git commit: "-a -m 'Add healthcheck endpoint'"
+
+# Configure code coverage
+gem_group :development, :test do
+  gem 'simplecov', :require => false
+  gem 'simplecov-rcov', :require => false
+end
+
+inject_into_file 'spec/rails_helper.rb', after: "require 'rspec/rails'\n" do <<-'RUBY'
+require 'simplecov'
+require 'simplecov-rcov'
+SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+SimpleCov.start 'rails'
+RUBY
+end
+
+run 'bundle install'
+append_to_file '.gitignore', "/coverage\n"
+
+git add: "."
+git commit: "-a -m 'Use simplecov for code coverage reporting'"

--- a/template.rb
+++ b/template.rb
@@ -9,6 +9,7 @@ gem_group :development, :test do
   gem 'rspec-rails'
 end
 generate(:"rspec:install")
+remove_dir('test')
 
 # Lock Ruby version
 file '.ruby-version', '2.2.2'

--- a/template.rb
+++ b/template.rb
@@ -12,6 +12,10 @@ remove_file 'README.rdoc'
 template 'templates/README.md.erb', 'README.md'
 template 'templates/LICENSE.erb', 'LICENSE'
 
+# Boilerplate jenkins scripts
+copy_file 'templates/jenkins.sh', 'jenkins.sh'
+template  'templates/jenkins_branches.sh.erb', 'jenkins_branches.sh'
+
 # Add a healthcheck route
 route "get '/healthcheck', :to => proc { [200, {}, ['OK']] }"
 

--- a/template.rb
+++ b/template.rb
@@ -23,8 +23,9 @@ template 'templates/LICENSE.erb', 'LICENSE'
 copy_file 'templates/jenkins.sh', 'jenkins.sh'
 template  'templates/jenkins_branches.sh.erb', 'jenkins_branches.sh'
 
-# Add a healthcheck route
+# Add a healthcheck route and specs
 route "get '/healthcheck', :to => proc { [200, {}, ['OK']] }"
+copy_file 'templates/spec/requests/healthcheck_spec.rb', 'spec/requests/healthcheck_spec.rb'
 
 # Enable JSON-formatted logging in production
 environment nil, env: "production" do <<-'RUBY'

--- a/template.rb
+++ b/template.rb
@@ -12,6 +12,9 @@ remove_file 'README.rdoc'
 template 'templates/README.md.erb', 'README.md'
 template 'templates/LICENSE.erb', 'LICENSE'
 
+# Add a healthcheck route
+route "get '/healthcheck', :to => proc { [200, {}, ['OK']] }"
+
 # Enable JSON-formatted logging in production
 environment nil, env: "production" do <<-'RUBY'
 config.logstasher.enabled = true

--- a/template.rb
+++ b/template.rb
@@ -27,8 +27,9 @@ git commit: "-a -m 'Use logstasher for JSON-formatted logging in production'"
 
 # Setup rspec
 gem_group :development, :test do
-  gem 'rspec-rails'
+  gem 'rspec-rails', '~> 3.3.0'
 end
+run 'bundle install'
 generate("rspec:install")
 remove_dir('test')
 git add: "."

--- a/template.rb
+++ b/template.rb
@@ -1,32 +1,14 @@
 # Include govuk-rails-app-template root in source_paths
 source_paths << File.dirname(__FILE__)
 
-# Add Dependent Gems
+run 'bundle install'
+git :init
+git add: "."
+git commit: "-a -m 'Bare Rails application'"
+
+# Configure JSON-formatted logging
 gem 'logstasher'
-
-# Setup rspec
-gem_group :development, :test do
-  gem 'rspec-rails'
-end
-generate(:"rspec:install")
-remove_dir('test')
-
-# Lock Ruby version
-file '.ruby-version', '2.2.2'
-
-# Boilerplate README and LICENSE files
-remove_file 'README.rdoc'
-template 'templates/README.md.erb', 'README.md'
-template 'templates/LICENSE.erb', 'LICENSE'
-
-# Boilerplate jenkins scripts
-copy_file 'templates/jenkins.sh', 'jenkins.sh'
-template  'templates/jenkins_branches.sh.erb', 'jenkins_branches.sh'
-
-# Add a healthcheck route and specs
-route "get '/healthcheck', :to => proc { [200, {}, ['OK']] }"
-copy_file 'templates/spec/requests/healthcheck_spec.rb', 'spec/requests/healthcheck_spec.rb'
-
+run 'bundle install'
 # Enable JSON-formatted logging in production
 environment nil, env: "production" do <<-'RUBY'
 config.logstasher.enabled = true
@@ -39,3 +21,43 @@ gsub_file 'config/environments/production.rb', 'config.log_formatter = ::Logger:
 
 # Configure JSON-formatted logging with additional fields
 initializer "logstasher.rb", File.read("#{File.dirname(__FILE__)}/templates/initializers/logstasher.rb")
+
+git add: "."
+git commit: "-a -m 'Use logstasher for JSON-formatted logging in production'"
+
+# Setup rspec
+gem_group :development, :test do
+  gem 'rspec-rails'
+end
+generate(:"rspec:install")
+remove_dir('test')
+git add: "."
+git commit: "-a -m 'Use rspec-rails for testing'"
+
+# Lock Ruby version
+file '.ruby-version', "2.2.2\n"
+
+git add: "."
+git commit: "-a -m 'Lock Ruby version'"
+
+# Boilerplate README and LICENSE files
+remove_file 'README.rdoc'
+template 'templates/README.md.erb', 'README.md'
+template 'templates/LICENSE.erb', 'LICENSE'
+
+git add: "."
+git commit: "-a -m 'Add README.md and LICENSE'"
+
+# Boilerplate jenkins scripts
+copy_file 'templates/jenkins.sh', 'jenkins.sh'
+template  'templates/jenkins_branches.sh.erb', 'jenkins_branches.sh'
+
+git add: "."
+git commit: "-a -m 'Add Jenkins scripts'"
+
+# Add a healthcheck route and specs
+route "get '/healthcheck', :to => proc { [200, {}, ['OK']] }"
+copy_file 'templates/spec/requests/healthcheck_spec.rb', 'spec/requests/healthcheck_spec.rb'
+
+git add: "."
+git commit: "-a -m 'Add healthcheck endpoint'"

--- a/template.rb
+++ b/template.rb
@@ -52,6 +52,8 @@ git commit: "-a -m 'Add README.md and LICENSE'"
 # Boilerplate jenkins scripts
 copy_file 'templates/jenkins.sh', 'jenkins.sh'
 template  'templates/jenkins_branches.sh.erb', 'jenkins_branches.sh'
+chmod 'jenkins.sh', 0755
+chmod 'jenkins_branches.sh', 0755
 
 git add: "."
 git commit: "-a -m 'Add Jenkins scripts'"

--- a/template.rb
+++ b/template.rb
@@ -1,0 +1,25 @@
+# Add Dependent Gems
+gem 'logstasher'
+
+# Enable JSON-formatted logging in production
+application nil, env: "production" do <<-'RUBY'
+config.logstasher.enabled = true
+  config.logstasher.logger = Logger.new(Rails.root.join("/log/production.json.log"))
+  config.logstasher.suppress_app_log = true
+RUBY
+end
+# Remove the default log formatter
+gsub_file 'config/environments/production.rb', 'config.log_formatter = ::Logger::Formatter.new', '# config.log_formatter = ::Logger::Formatter.new'
+
+# Configure JSON-formatted logging with additional fields
+initializer "logstasher.rb" do <<-'RUBY'
+if Object.const_defined?('LogStasher') && LogStasher.enabled
+  LogStasher.add_custom_fields do |fields|
+    # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
+    fields[:request] = "\#{request.request_method} \#{request.fullpath} \#{request.headers['SERVER_PROTOCOL']}"
+    # Pass request Id to logging
+    fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
+  end
+end
+RUBY
+end

--- a/template.rb
+++ b/template.rb
@@ -4,6 +4,12 @@ source_paths << File.dirname(__FILE__)
 # Add Dependent Gems
 gem 'logstasher'
 
+# Setup rspec
+gem_group :development, :test do
+  gem 'rspec-rails'
+end
+generate(:"rspec:install")
+
 # Lock Ruby version
 file '.ruby-version', '2.2.2'
 

--- a/template.rb
+++ b/template.rb
@@ -1,6 +1,9 @@
 # Add Dependent Gems
 gem 'logstasher'
 
+# Lock Ruby version
+file '.ruby-version', '2.2.2'
+
 # Enable JSON-formatted logging in production
 application nil, env: "production" do <<-'RUBY'
 config.logstasher.enabled = true

--- a/template.rb
+++ b/template.rb
@@ -7,7 +7,7 @@ git add: "."
 git commit: "-a -m 'Bare Rails application\nGenerated using https://github.com/alphagov/govuk-rails-app-template'"
 
 # Configure JSON-formatted logging
-gem 'logstasher'
+gem 'logstasher', '0.6.5'
 run 'bundle install'
 # Enable JSON-formatted logging in production
 environment nil, env: "production" do <<-'RUBY'
@@ -27,7 +27,7 @@ git commit: "-a -m 'Use logstasher for JSON-formatted logging in production'"
 
 # Setup rspec
 gem_group :development, :test do
-  gem 'rspec-rails', '~> 3.3.0'
+  gem 'rspec-rails', '~> 3.3'
 end
 run 'bundle install'
 generate("rspec:install")
@@ -67,8 +67,8 @@ git commit: "-a -m 'Add healthcheck endpoint'"
 
 # Configure code coverage
 gem_group :development, :test do
-  gem 'simplecov', :require => false
-  gem 'simplecov-rcov', :require => false
+  gem 'simplecov', '0.10.0', :require => false
+  gem 'simplecov-rcov', '0.2.3', :require => false
 end
 
 prepend_to_file 'spec/rails_helper.rb' do <<-'RUBY'

--- a/template.rb
+++ b/template.rb
@@ -69,7 +69,7 @@ gem_group :development, :test do
   gem 'simplecov-rcov', :require => false
 end
 
-inject_into_file 'spec/rails_helper.rb', after: "require 'rspec/rails'\n" do <<-'RUBY'
+prepend_to_file 'spec/rails_helper.rb' do <<-'RUBY'
 require 'simplecov'
 require 'simplecov-rcov'
 SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter

--- a/template.rb
+++ b/template.rb
@@ -1,8 +1,16 @@
+# Include govuk-rails-app-template root in source_paths
+source_paths << File.dirname(__FILE__)
+
 # Add Dependent Gems
 gem 'logstasher'
 
 # Lock Ruby version
 file '.ruby-version', '2.2.2'
+
+# Boilerplate README and LICENSE files
+remove_file 'README.rdoc'
+template 'templates/README.md.erb', 'README.md'
+template 'templates/LICENSE.erb', 'LICENSE'
 
 # Enable JSON-formatted logging in production
 application nil, env: "production" do <<-'RUBY'

--- a/templates/LICENSE.erb
+++ b/templates/LICENSE.erb
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) <%= Date.today.year %> Crown Copyright (Government Digital Service)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/templates/README.md.erb
+++ b/templates/README.md.erb
@@ -1,0 +1,50 @@
+# <%= app_name.humanize %>
+
+One paragraph description and purpose.
+
+## Screenshots (if there's a client-facing aspect of it)
+
+## Live examples (if available)
+
+- [gov.uk/thing](https://www.gov.uk/thing)
+
+## Nomenclature
+
+- **Word**: definition of word, and how it's used in the code
+
+## Technical documentation
+
+Write a single paragraph including a general technical overview of the app.
+Example:
+
+This is a Ruby on Rails application that maps RESTful URLs onto a persistence
+layer. It's only presented as an internal API and doesn't face public users.
+
+### Dependencies
+
+- [alphagov/other-repo]() - provides some downstream service
+- [redis]() - provides a backing service for work queues
+
+### Running the application
+
+`./startup.sh`
+
+Documentation for where the app will appear (default port, vhost, URL etc).
+
+### Running the test suite
+
+`bundle exec rake`
+
+Include any other edge cases, e.g parallel test runner in Whitehall
+
+### Any deviations from idiomatic Rails/Go etc. (optional)
+
+### Example API output (optional)
+
+`one-line-curl-command with JSON response after`
+
+Keep this section limited to core endpoints - if the app is complex link out to `/docs`.
+
+## Licence
+
+[MIT License](LICENCE)

--- a/templates/initializers/logstasher.rb
+++ b/templates/initializers/logstasher.rb
@@ -1,0 +1,8 @@
+if Object.const_defined?('LogStasher') && LogStasher.enabled
+  LogStasher.add_custom_fields do |fields|
+    # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
+    fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
+    # Pass request Id to logging
+    fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
+  end
+end

--- a/templates/jenkins.sh
+++ b/templates/jenkins.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -x
+set -e
+export RAILS_ENV=test
+
+git clean -fdx
+bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+bundle exec rake

--- a/templates/jenkins_branches.sh.erb
+++ b/templates/jenkins_branches.sh.erb
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+VENV_PATH="${HOME}/venv/${JOB_NAME}"
+
+[ -x ${VENV_PATH}/bin/pip ] || virtualenv ${VENV_PATH}
+. ${VENV_PATH}/bin/activate
+
+pip install -q ghtools
+
+REPO="alphagov/<%= app_name %>"
+gh-status "$REPO" "$GIT_COMMIT" pending -d "\"Build #${BUILD_NUMBER} is running on Jenkins\"" -u "$BUILD_URL" >/dev/null
+
+if ./jenkins.sh; then
+  gh-status "$REPO" "$GIT_COMMIT" success -d "\"Build #${BUILD_NUMBER} succeeded on Jenkins\"" -u "$BUILD_URL" >/dev/null
+  exit 0
+else
+  gh-status "$REPO" "$GIT_COMMIT" failure -d "\"Build #${BUILD_NUMBER} failed on Jenkins\"" -u "$BUILD_URL" >/dev/null
+  exit 1
+fi

--- a/templates/spec/requests/healthcheck_spec.rb
+++ b/templates/spec/requests/healthcheck_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "healthcheck path", :type => :request do
+  it "should respond with 'OK'" do
+    get "/healthcheck"
+
+    expect(response.status).to eq(200)
+    expect(response.body).to eq("OK")
+  end
+end


### PR DESCRIPTION
A first-pass rails app template for creating and configuring a bare Rails application with common GOV.UK features. This should save a fair amount of time when starting a fresh Rails application on GOV.UK.

As outlined in the [README](https://github.com/alphagov/govuk-rails-app-template/blob/044e15b07201fe1e77d88a6212c2d4c5b1c7a1c0/README.md#how-to-use), a new app can be generated as follows:

``` shell
rails new APP_NAME --skip-test-unit --skip-spring -m govuk-rails-app-template/template.rb
```

This will generate a new rails application, and also do the following:
- Install and configure rspec for testing, skipping test-unit
- Install and configure logstasher for JSON-formatted log output in production
- Install and configure simple-cov for code coverage reporting
- Add a `.ruby-version` file
- Add a skeleton `README.md` based on the [styleguide](https://github.com/alphagov/styleguides/blob/master/use-of-READMEs.md)
- Add a `LICENSE` file
- Add jenkins scripts for master and branch builds
- Add a `/healthcheck` endpoint, including test

This makes use of the [Rails application templating](http://guides.rubyonrails.org/rails_application_templates.html) functionality, which is a wrapper around [thor](http://www.rubydoc.info/github/erikhuda/thor/master/Thor/Actions).
