### PR TITLE
Downgrade the version of logstasher to 0.6.2

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -10,7 +10,7 @@ command = "#{File.basename($0)} #{ARGV.join(' ')}"
 git commit: "-a -m 'Bare Rails application\n\nGenerated using https://github.com/alphagov/govuk-rails-app-template\nCommand: #{command}'"
 
 # Configure JSON-formatted logging
-gem 'logstasher', '0.6.5'
+gem 'logstasher', '0.6.2' # 0.6.5+ change the json schema used for events
 run 'bundle install'
 # Enable JSON-formatted logging in production
 environment nil, env: "production" do <<-'RUBY'


### PR DESCRIPTION
Version 0.6.5+ change the schema used in JSON events to use the
logstasher 1.2 schema. This puts everything at the top level, not in the
@fields key. This means that the Rails log details from this app are in
different fields to all the other log entries in Kibana.

See https://logstash.jira.com/browse/LOGSTASH-675.
