### PR TITLE
Add govuk lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ RBENV_VERSION=2.2.2 rails new APP_NAME --skip-javascript --skip-test-unit --skip
 
 9. Set up airbrake for errbit-based error reporting
 
+10. Add govuk-lint and run it in diff mode as part of the jenkins script
 
 Further details on setting up a new Rails application on the GOV.UK stack can be
 found over on the [Ops Manual](https://github.gds/pages/gds/opsmanual/infrastructure/howto/setting-up-new-rails-app.html).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GOV.UK stack.
 ## How to use
 
 ```shell
-RBENV_VERSION=2.2.2 rails new APP_NAME --skip-javascript --skip-test-unit --skip-spring -m govuk-rails-app-template/template.rb
+RBENV_VERSION=2.2.3 rails new APP_NAME --skip-javascript --skip-test-unit --skip-spring -m govuk-rails-app-template/template.rb
 ```
 
 ## What it will do

--- a/template.rb
+++ b/template.rb
@@ -38,6 +38,14 @@ remove_dir('test')
 git add: "."
 git commit: "-a -m 'Use rspec-rails for testing'"
 
+# Add govuk-lint
+gem_group :development, :test do
+  gem 'govuk-lint'
+end
+run 'bundle install'
+git add: "."
+git commit: "-a -m 'Add govuk-lint for enforcing GOV.UK styleguide'"
+
 # Lock Ruby version
 file '.ruby-version', "2.2.3\n"
 

--- a/template.rb
+++ b/template.rb
@@ -68,7 +68,7 @@ git add: "."
 git commit: "-a -m 'Add Jenkins scripts'"
 
 # Add a healthcheck route and specs
-route "get '/healthcheck', :to => proc { [200, {}, ['OK']] }"
+route "get '/healthcheck', to: proc { [200, {}, ['OK']] }"
 copy_file 'templates/spec/requests/healthcheck_spec.rb', 'spec/requests/healthcheck_spec.rb'
 
 git add: "."

--- a/templates/jenkins.sh.erb
+++ b/templates/jenkins.sh.erb
@@ -35,6 +35,16 @@ git clean -fdx
 # is master.
 git merge --no-commit origin/master || git merge --abort
 
+# Lint changes introduced in this branch, but not for master
+if [[ ${GIT_BRANCH} != "origin/master" ]]; then
+  bundle exec govuk-lint-ruby \
+    --diff \
+    --cached \
+    --format html --out rubocop-${GIT_COMMIT}.html \
+    --format clang \
+    app spec lib
+fi
+
 export RAILS_ENV=test
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
 

--- a/templates/spec/requests/healthcheck_spec.rb
+++ b/templates/spec/requests/healthcheck_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "healthcheck path", :type => :request do
+RSpec.describe "healthcheck path", type: :request do
   it "should respond with 'OK'" do
     get "/healthcheck"
 


### PR DESCRIPTION
We add it as a gem dependency and to the jenkins.sh template to run in diff mode on non-master branches only ([just like whitehall](https://github.com/alphagov/whitehall/blob/ec3932e8194a12b2b681205cffb829a6e82718bf/jenkins.sh#L52-L60)).  Also attempted to create an app that doesn't have lint errors from the off, but we don't control all the files created :(
