### PR TITLE
Expose ruby version via Gemfile

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -40,6 +40,7 @@ git commit: "-a -m 'Use rspec-rails for testing'"
 
 # Lock Ruby version
 file '.ruby-version', "2.2.3\n"
+prepend_to_file('Gemfile') { "ruby File.read('.ruby-version').strip\n" }
 
 git add: "."
 git commit: "-a -m 'Lock Ruby version'"


### PR DESCRIPTION
This pattern has been used on a [few](https://github.com/alphagov/govuk-content-schemas/pull/230) [repos](https://github.com/alphagov/government-frontend/blob/master/Gemfile#L3) that have needed
to be run on Heroku, where `.ruby-version` is not respected, and the
version must be set via `Gemfile` instead.

It's not uncommon for us to deploy applications to Heroku for
prototyping, and as applications become simpler, and depend on fewer
services (eg, moving to content store) the easier, and more likely
we are to do it in the future.

This commit future-proofs new apps, so they will Just Work in that
situation. It should also act as a canonical record of the pattern,
and our reasons for the choice, rather than both being spread across
many apps.,

We use `ruby-version` over `Gemfile` as it's not dependant on `bundler`,
and also because our target platform (production and VMs) use `rbenv`,
which does not support `.ruby-version`.

Most recent discussion here: https://github.com/alphagov/govuk-content-schemas/pull/230
