### PR TITLE
Add sass linting when running linters

### DIFF
--- a/templates/jenkins.sh.erb
+++ b/templates/jenkins.sh.erb
@@ -43,6 +43,8 @@ if [[ ${GIT_BRANCH} != "origin/master" ]]; then
     --format html --out rubocop-${GIT_COMMIT}.html \
     --format clang \
     app spec lib
+
+  bundle exec govuk-lint-sass app
 fi
 
 export RAILS_ENV=test


### PR DESCRIPTION
- As of govuk-lint 0.6.1 sass linting is supported.
