### PR TITLE
Bump to Rails 5 app by default

### DIFF
--- a/templates/Gemfile
+++ b/templates/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rails", "4.2.6"
+gem "rails", "5.0.2"
 gem "unicorn", "~> 5.1.0"
 group :development, :test do
   gem "byebug" # Comes standard with Rails


### PR DESCRIPTION
It feels a bit icky to have exact version defined here but looks a
somewhat painful task to loosen this up.