### PR TITLE
Update Airbrake gem to alphagov fork

### DIFF
--- a/lib/govuk_rails_template.rb
+++ b/lib/govuk_rails_template.rb
@@ -229,7 +229,7 @@ RUBY
   end
 
   def add_errbit
-    add_gem "airbrake", "~> 5.4.1"
+    add_gem "airbrake", github: 'alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
     app.run "bundle install"
 
     app.copy_file "templates/config/initializers/airbrake.rb", "config/initializers/airbrake.rb"


### PR DESCRIPTION
The default Airbrake installation throws lots of initialisation warnings. This update changes the install path to the GOV.UK fork which is both compatible with Rails 5, our Errbit install, and has been patched to silence the warnings.