### PR TITLE
Fix ActiveRecord::Migration error in generated app

### DIFF
--- a/templates/db/migrate/20160622154200_create_users.rb
+++ b/templates/db/migrate/20160622154200_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[5.1]
   def change
     create_table :users do |t|
       t.string   :name


### PR DESCRIPTION
Rails 5 isn't happy that we inherited a migration directly from the `ActiveRecord::Migration` superclass. 

Instead, the new Rails convention is to inherit from the versioned Migration class, `ActiveRecord::Migration[5.1]`