### PR TITLE
Upgrade the version of the logstasher gem to 1.x

### DIFF
--- a/lib/govuk_rails_template.rb
+++ b/lib/govuk_rails_template.rb
@@ -44,7 +44,7 @@ private
   end
 
   def add_json_logging
-    add_gem "logstasher", "0.6.2" # 0.6.5+ change the json schema used for events
+    add_gem "logstasher", "1.2.1"
     app.run "bundle install"
 
     # Enable JSON-formatted logging in production


### PR DESCRIPTION
- 1.x versions change the log format. It seems that anything below v1
  adds a `@fields` hash which contains data such as request, duration etc.
  Anything above v1 does not contain this hash, and outputs this
  information as a top level object in the JSON output.
  (https://github.com/alphagov/govuk-puppet/pull/6650)
- This is a start at upgrading this gem to be consistently versioned
  across all apps, and why not start with the app template that will
  inform creation of any new Rails apps. Whitehall and a few other apps
  are already on this version.