### PR TITLE
Update the GDS::SSO template to use external_url_for

### DIFF
--- a/templates/config/initializers/gds-sso.rb
+++ b/templates/config/initializers/gds-sso.rb
@@ -2,5 +2,5 @@ GDS::SSO.config do |config|
   config.user_model   = "User"
   config.oauth_id     = ENV["OAUTH_ID"]
   config.oauth_secret = ENV["OAUTH_SECRET"]
-  config.oauth_root_url = Plek.find("signon")
+  config.oauth_root_url = Plek.new.external_url_for("signon")
 end


### PR DESCRIPTION
The oauth_root_url needs to be the external URL for Signon, so use the
new external_url_for method of Plek.