### PR TITLE
Update template for Jenkinsfile

### DIFF
--- a/templates/Jenkinsfile
+++ b/templates/Jenkinsfile
@@ -1,6 +1,7 @@
 #!/usr/bin/env groovy
 
+library("govuk")
+
 node {
-  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
   govuk.buildProject()
 }


### PR DESCRIPTION
We now load the library from an external library: [govuk-jenkinslib](https://github.com/alphagov/govuk-jenkinslib/).

This references the library called "govuk" when it has been loaded into the Jenkins configuration.

https://trello.com/c/88RFcs4R/994-make-jenkinslibgroovy-its-own-repo-refactor