### PR TITLE
Update for GOV.UK gems

### DIFF
--- a/lib/govuk_admin_template.rb
+++ b/lib/govuk_admin_template.rb
@@ -4,7 +4,6 @@ class GovukAdminTemplate < GovukRailsTemplate
   def apply
     create_bare_rails_app
     add_gemfile
-    add_json_logging
     add_test_framework
     add_gds_sso
     add_linter

--- a/lib/govuk_api_template.rb
+++ b/lib/govuk_api_template.rb
@@ -4,7 +4,6 @@ class GovukAPITemplate < GovukRailsTemplate
   def apply
     create_bare_rails_app
     add_gemfile
-    add_json_logging
     add_test_framework
     add_gds_sso
     add_linter

--- a/lib/govuk_frontend_template.rb
+++ b/lib/govuk_frontend_template.rb
@@ -4,7 +4,6 @@ class GovukFrontendTemplate < GovukRailsTemplate
   def apply
     create_bare_rails_app
     add_gemfile
-    add_json_logging
     add_test_framework
     add_linter
     lock_ruby_version

--- a/lib/govuk_rails_template.rb
+++ b/lib/govuk_rails_template.rb
@@ -93,7 +93,7 @@ RUBY
     app.inject_into_file "app/controllers/application_controller.rb", after: "class ApplicationController < ActionController::Base\n" do <<-"RUBY"
   include GDS::SSO::ControllerMethods
 
-  before_action :require_signin_permission!
+  before_action :authenticate_user!!
 
 RUBY
     end

--- a/lib/govuk_rails_template.rb
+++ b/lib/govuk_rails_template.rb
@@ -43,28 +43,6 @@ private
     commit "Start with a lean Gemfile"
   end
 
-  def add_json_logging
-    add_gem "logstasher", "0.6.2" # 0.6.5+ change the json schema used for events
-    app.run "bundle install"
-
-    # Enable JSON-formatted logging in production
-    app.environment nil, env: "production" do <<-'RUBY'
-  config.logstasher.enabled = true
-  config.logstasher.logger = Logger.new(Rails.root.join("log/production.json.log"))
-  config.logstasher.suppress_app_log = true
-RUBY
-    end
-
-    # Remove the default log formatter
-    app.gsub_file "config/environments/production.rb", "config.log_formatter = ::Logger::Formatter.new", "# config.log_formatter = ::Logger::Formatter.new"
-
-    # Configure JSON-formatted logging with additional fields
-    app.copy_file "templates/config/initializers/logstasher.rb", "config/initializers/logstasher.rb"
-
-    app.git add: "."
-    commit "Use logstasher for JSON-formatted logging in production"
-  end
-
   def setup_database
     return if @database_created
 
@@ -231,7 +209,10 @@ RUBY
   def add_govuk_app_config
     add_gem "govuk_app_config"
     app.run "bundle install"
-    commit "Add govuk_app_config for error reporting"
+
+    app.copy_file "templates/config/unicorn.rb", "config/unicorn.rb"
+
+    commit "Add govuk_app_config for error reporting, stats, logging and unicorn"
   end
 
   def add_debuggers

--- a/templates/Gemfile
+++ b/templates/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 gem "rails", "5.1.0"
-gem "unicorn", "~> 5.1.0"
 group :development, :test do
   gem "byebug" # Comes standard with Rails
 end

--- a/templates/config/initializers/logstasher.rb
+++ b/templates/config/initializers/logstasher.rb
@@ -1,8 +1,0 @@
-if Object.const_defined?("LogStasher") && LogStasher.enabled
-  LogStasher.add_custom_fields do |fields|
-    # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
-    fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers["SERVER_PROTOCOL"]}"
-    # Pass request Id to logging
-    fields[:govuk_request_id] = request.headers["GOVUK-Request-Id"]
-  end
-end

--- a/templates/config/unicorn.rb
+++ b/templates/config/unicorn.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_unicorn"
+GovukUnicorn.configure(self)


### PR DESCRIPTION
## Update for govuk_app_config changes

This updates the set up to work with [govuk_app_config up until v1.3.2](https://github.com/alphagov/govuk_app_config/blob/master/CHANGELOG.md#132).

We no longer need to do logging configuration.

The unicorn gem can be removed (because it's a dependency of govuk_app_config now), although we should add the unicorn.rb configuration file.

## Update for signon changes

As per [gds-sso's instructions](https://github.com/alphagov/gds-sso/blob/3cad88bf36b35a7ee91a5af932f658cfb9f010d8/README.md#securing-your-application) the `require_signin_permission!` has been deprecated as Signon will do this for us.

For app specific access control, we now need to `authenticate_user!`.