### PR TITLE
Update Rails templates

### DIFF
--- a/lib/govuk_admin_template.rb
+++ b/lib/govuk_admin_template.rb
@@ -14,9 +14,7 @@ class GovukAdminTemplate < GovukRailsTemplate
     add_health_check
     add_govuk_app_config
     add_debuggers
-    add_form_builder
     add_frontend_development_libraries
-    add_govuk_admin_frontend_template
     add_browser_testing_framework
     add_gds_api_adapters
   end

--- a/lib/govuk_rails_template.rb
+++ b/lib/govuk_rails_template.rb
@@ -155,7 +155,7 @@ RUBY
   end
 
   def lock_ruby_version
-    app.add_file ".ruby-version", "2.4.2\n"
+    app.add_file ".ruby-version", "2.4.4\n"
     app.prepend_to_file("Gemfile") { %{ruby File.read(".ruby-version").strip\n\n} }
 
     commit "Lock Ruby version"

--- a/lib/govuk_rails_template.rb
+++ b/lib/govuk_rails_template.rb
@@ -230,25 +230,6 @@ RUBY
     commit "Add common debuggers"
   end
 
-  def add_form_builder
-    add_gem "selectize-rails"
-    add_gem "generic_form_builder"
-
-    app.run "bundle install"
-
-    app.application do <<-'RUBY'
-# Better forms
-    require "admin_form_builder"
-    config.action_view.default_form_builder = AdminFormBuilder
-    config.action_view.field_error_proc = proc {|html_tag, _| html_tag }
-RUBY
-    end
-
-    app.copy_file "templates/lib/admin_form_builder.rb", "lib/admin_form_builder.rb"
-
-    commit "Add a form builder"
-  end
-
   def add_frontend_development_libraries
     add_gem "sass-rails"
     add_gem "uglifier"
@@ -257,16 +238,6 @@ RUBY
     app.run "bundle install"
 
     commit "Add frontend development libraries"
-  end
-
-  def add_govuk_admin_frontend_template
-    add_gem "govuk_admin_template"
-
-    app.run "bundle install"
-
-    commit "Add the admin frontend template"
-
-    instructions << "Setup the admin template as per https://github.com/alphagov/govuk_admin_template#govuk-admin-template"
   end
 
   def add_browser_testing_framework

--- a/lib/govuk_rails_template.rb
+++ b/lib/govuk_rails_template.rb
@@ -213,6 +213,8 @@ RUBY
     app.copy_file "templates/config/unicorn.rb", "config/unicorn.rb"
 
     commit "Add govuk_app_config for error reporting, stats, logging and unicorn"
+
+    instructions << "Add healthchecks for your app: https://github.com/alphagov/govuk_app_config#healthchecks"
   end
 
   def add_debuggers

--- a/lib/govuk_rails_template.rb
+++ b/lib/govuk_rails_template.rb
@@ -132,7 +132,7 @@ RUBY
     add_test_gem "rspec-rails"
     add_test_gem "webmock", require: false
     add_test_gem "timecop"
-    add_test_gem "factory_girl_rails"
+    add_test_gem "factory_bot_rails"
 
     app.run "bundle install"
 

--- a/templates/Gemfile
+++ b/templates/Gemfile
@@ -1,6 +1,8 @@
 source "https://rubygems.org"
 
-gem "rails", "5.1.0"
+gem "rails", "5.2.0"
+gem "bootsnap"
+
 group :development, :test do
   gem "byebug" # Comes standard with Rails
 end


### PR DESCRIPTION
The controversial bit of this is probably removing the `govuk_admin_template` and forms helpers gems from the admin/publishing template.

We are about to create a new publishing app, but don't want to get tied into the old world, when we should be aiming to reuse frontend components where possible and create new components where needed.  This doesn't preclude adding them back in if required.

I have deliberately not added the `govuk_publishing_components` gem to the admin template at this time because it has a few extra dependencies that we want to be a little careful about adding to other apps just yet.

This is part of our work to create a new app: https://trello.com/c/nwhf5EaC/74-create-new-rails-app