### PR TITLE
Skip more rails frameworks by default

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -25,4 +25,4 @@ else
 fi
 
 set RBENV_VERSION=2.4.4
-rails new $app_name --skip-javascript --skip-test-unit --skip-bundle --skip-spring -m govuk-rails-app-template/$template.rb
+rails new $app_name --skip-javascript --skip-test-unit --skip-bundle --skip-spring --skip-action-cable --skip-action-mailer --skip-active-storage -m govuk-rails-app-template/$template.rb


### PR DESCRIPTION
https://trello.com/c/CPWJzL9y/5-create-skeleton-rails-app

It's unusual for us to use: ActionMailer, ActionCable and ActiveStorage,
so let's skip these when creating a new app, by default.